### PR TITLE
Fix pull-model loop, capture Ollama errors, version-check Ollama

### DIFF
--- a/deploy/get-cerberus.ps1
+++ b/deploy/get-cerberus.ps1
@@ -4,6 +4,11 @@
 #
 # Or from cmd.exe (Win10+, curl is built-in):
 #   curl -sSL https://cerberusai.dev/get -o "%TEMP%\get-cerberus.ps1" && powershell -ep bypass -File "%TEMP%\get-cerberus.ps1"
+#
+# This bootstrapper hands off to deploy/install.ps1 in the latest release. That
+# script handles Ollama, WebView2, and the Cerberus app itself, so a fresh
+# Windows install ends up fully working — not just the desktop app sitting on a
+# machine without Ollama.
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference    = "SilentlyContinue"
@@ -13,29 +18,53 @@ Write-Host "  CERBERUS AI" -ForegroundColor Red
 Write-Host "  Bootstrapping installer..." -ForegroundColor DarkGray
 Write-Host ""
 
-$api   = "https://api.github.com/repos/tjcrims0nx/CerberusAI-Desktop/releases/latest"
-$tmp   = $env:TEMP
+$repoOwner = "tjcrims0nx"
+$repoName  = "CerberusAI-Desktop"
+$api       = "https://api.github.com/repos/$repoOwner/$repoName/releases/latest"
+$tmp       = $env:TEMP
 
 try {
-    $rel   = Invoke-RestMethod -Uri $api -Headers @{"User-Agent"="CerberusBootstrap"} -TimeoutSec 15
-    $asset = $rel.assets | Where-Object { $_.name -match "(?i)(cerberus.*setup\.exe|cerberus.*-windows.*\.exe)$" } |
-             Select-Object -First 1
+    $rel = Invoke-RestMethod -Uri $api -Headers @{ "User-Agent" = "CerberusBootstrap" } -TimeoutSec 15
+    $tag = $rel.tag_name
 
-    if (-not $asset) {
-        # Fallback: any .exe in the release
-        $asset = $rel.assets | Where-Object { $_.name -match "\.exe$" } | Select-Object -First 1
+    # 1. Pull the deploy/install.ps1 from the same release tag so the
+    #    bootstrapper and the script never drift in version.
+    $installScriptUrl = "https://raw.githubusercontent.com/$repoOwner/$repoName/$tag/deploy/install.ps1"
+    $installScript    = Join-Path $tmp "cerberus-install.ps1"
+
+    Write-Host "  Fetching installer ($tag)..." -ForegroundColor DarkGray
+    try {
+        Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScript -UseBasicParsing
+    } catch {
+        # Fall back to the raw .exe path if the release tag predates the install.ps1 script.
+        Write-Host "  Release $tag has no install.ps1; falling back to direct app installer." -ForegroundColor Yellow
+        $asset = $rel.assets | Where-Object { $_.name -match "(?i)cerberus.*-setup\.exe$" } | Select-Object -First 1
+        if (-not $asset) {
+            $asset = $rel.assets | Where-Object { $_.name -match "\.exe$" } | Select-Object -First 1
+        }
+        if (-not $asset) {
+            throw "No installer found in release $tag. Visit https://github.com/$repoOwner/$repoName/releases"
+        }
+        $dest = Join-Path $tmp $asset.name
+        Write-Host "  Downloading $($asset.name)..." -ForegroundColor DarkGray
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $dest -UseBasicParsing
+        Write-Host "  Running app installer (no Ollama bootstrap available for this release)..." -ForegroundColor DarkGray
+        Start-Process -FilePath $dest -Wait
+        Write-Host ""
+        Write-Host "  Done. If Ollama is not installed, get it from https://ollama.com/download" -ForegroundColor Yellow
+        Start-Sleep -Seconds 2
+        exit 0
     }
 
-    if (-not $asset) {
-        throw "No installer found in release $($rel.tag_name). Visit https://github.com/tjcrims0nx/CerberusAI-Desktop/releases"
+    # 2. Run install.ps1 — it handles WebView2, Ollama (winget or direct .exe),
+    #    a default model, and the Cerberus desktop app itself.
+    Write-Host "  Running full installer (WebView2 + Ollama + Cerberus)..." -ForegroundColor DarkGray
+    Write-Host ""
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installScript -ReleaseTag $tag
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0) {
+        throw "Installer exited with code $rc."
     }
-
-    $dest = Join-Path $tmp $asset.name
-    Write-Host "  Downloading $($asset.name) from $($rel.tag_name)..." -ForegroundColor DarkGray
-    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $dest -UseBasicParsing
-
-    Write-Host "  Running installer..." -ForegroundColor DarkGray
-    Start-Process -FilePath $dest -Wait
 
     Write-Host ""
     Write-Host "  Done. Launch Cerberus from the Start Menu." -ForegroundColor Green
@@ -46,6 +75,7 @@ try {
 
 } catch {
     Write-Host "  ERROR: $_" -ForegroundColor Red
-    Write-Host "  Manual download: https://github.com/tjcrims0nx/CerberusAI-Desktop/releases" -ForegroundColor Yellow
+    Write-Host "  Manual download: https://github.com/$repoOwner/$repoName/releases" -ForegroundColor Yellow
+    Write-Host "  Or install Ollama yourself:  https://ollama.com/download" -ForegroundColor Yellow
     exit 1
 }

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -289,6 +289,30 @@ function Get-PrimaryGpu {
     } catch { return $null }
 }
 
+# Probe nvidia-smi for driver version + CUDA support. Returns $null when no
+# NVIDIA driver is present (the user may still have an NVIDIA card but with
+# missing/broken drivers, which we want to warn about).
+#
+# Ollama 0.4+ requires NVIDIA driver >= 525 for CUDA support. Driver < 525
+# means inference silently falls back to CPU regardless of the GPU.
+function Get-NvidiaDriverInfo {
+    if (-not (Test-Command "nvidia-smi")) { return $null }
+    try {
+        $line = & nvidia-smi --query-gpu=driver_version,name --format=csv,noheader,nounits 2>$null | Select-Object -First 1
+        if (-not $line) { return $null }
+        $parts = $line.Split(",") | ForEach-Object { $_.Trim() }
+        if ($parts.Count -lt 1) { return $null }
+        $driver = $parts[0]
+        $major = 0
+        if ($driver -match '^(\d+)') { $major = [int]$Matches[1] }
+        return [pscustomobject]@{
+            Driver = $driver
+            Major  = $major
+            Name   = if ($parts.Count -ge 2) { $parts[1] } else { $null }
+        }
+    } catch { return $null }
+}
+
 function Get-FreeDiskGB {
     param([string]$Drive = $env:SystemDrive)
     try {
@@ -354,6 +378,22 @@ function Test-MinimumHardware {
         Write-Warn2 "No GPU with >=$REC_VRAM_GB GB VRAM detected. Inference will run on CPU at ~3-8 tokens/sec."
     } else {
         Write-OK "GPU acceleration available ($($gpu.Name), $vramGB GB VRAM)"
+
+        # NVIDIA driver sanity check. A user with an NVIDIA card but
+        # missing/old drivers will see Ollama "use GPU" in the UI and then
+        # silently fall back to CPU at runtime — the worst kind of bug.
+        if ($gpu.Name -match "NVIDIA|GeForce|RTX|GTX|Quadro|Tesla") {
+            $nv = Get-NvidiaDriverInfo
+            if (-not $nv) {
+                Write-Warn2 "NVIDIA GPU detected but nvidia-smi is missing. CUDA driver may not be installed; inference will fall back to CPU."
+                Write-Host "    Get the latest driver: https://www.nvidia.com/Download/index.aspx" -ForegroundColor DarkGray
+            } elseif ($nv.Major -lt 525) {
+                Write-Warn2 "NVIDIA driver $($nv.Driver) is older than the 525 minimum Ollama requires for CUDA. Inference will fall back to CPU."
+                Write-Host "    Update at: https://www.nvidia.com/Download/index.aspx" -ForegroundColor DarkGray
+            } else {
+                Write-OK "NVIDIA driver $($nv.Driver) is recent enough for CUDA inference"
+            }
+        }
     }
     Write-OK "Hardware passes minimum to run $MODEL_SMALLEST"
 }
@@ -392,6 +432,14 @@ function Invoke-Detect {
             "$($_.Name)$vram"
         }) -join " | "
     } catch { $report.GPU = "(detection failed)" }
+
+    $nv = Get-NvidiaDriverInfo
+    if ($nv) {
+        $status = if ($nv.Major -lt 525) { "TOO OLD (need >=525 for CUDA)" } else { "ok" }
+        $report.NvidiaDriver = "$($nv.Driver) ($status)"
+    } else {
+        $report.NvidiaDriver = "not detected"
+    }
 
     Write-Host "`n  Cerberus dependency report" -ForegroundColor Red
     Write-Host "  --------------------------" -ForegroundColor DarkGray

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -47,6 +47,7 @@ $RepoOwner    = "tjcrims0nx"
 $RepoName     = "CerberusAI-Desktop"
 $WebView2Url  = "https://go.microsoft.com/fwlink/p/?LinkId=2124703"   # Evergreen Bootstrapper
 $OllamaUrl    = "https://ollama.com/download/OllamaSetup.exe"
+$OllamaApi    = "https://api.github.com/repos/ollama/ollama/releases/latest"
 $WorkDir      = Join-Path $env:TEMP "CerberusInstall"
 
 # ---------- Custom Model Registry ----------
@@ -171,6 +172,74 @@ function Test-WingetReady {
         & winget --version *> $null
         return $LASTEXITCODE -eq 0
     } catch { return $false }
+}
+
+# ---------- Ollama version helpers ----------
+
+# Pull the latest Ollama Windows installer URL + version from GitHub Releases.
+# Returns $null on network failure so callers can fall back to ollama.com/download.
+function Get-LatestOllamaRelease {
+    try {
+        $rel = Invoke-RestMethod -Uri $OllamaApi -Headers @{ "User-Agent" = "CerberusInstaller" } -TimeoutSec 15
+    } catch {
+        Write-Warn2 "Could not reach GitHub for latest Ollama version ($($_.Exception.Message)). Falling back to ollama.com redirect."
+        return $null
+    }
+    $exe = $rel.assets | Where-Object { $_.name -ieq "OllamaSetup.exe" } | Select-Object -First 1
+    if (-not $exe) { return $null }
+    $sha = $rel.assets | Where-Object { $_.name -ieq "sha256sum.txt" } | Select-Object -First 1
+    return [pscustomobject]@{
+        Version = $rel.tag_name.TrimStart("v","V")
+        Url     = $exe.browser_download_url
+        Size    = $exe.size
+        ShaUrl  = if ($sha) { $sha.browser_download_url } else { $null }
+    }
+}
+
+# Read the version Ollama reports about itself. Prefers the running daemon
+# (most accurate); falls back to `ollama --version` for cases where the
+# daemon is installed but not running yet.
+function Get-InstalledOllamaVersion {
+    $svc = Get-OllamaVersion
+    if ($svc) { return $svc }
+    if (Test-Command "ollama") {
+        try {
+            $line = (& ollama --version 2>$null | Select-Object -First 1)
+            if ($line -match "(\d+\.\d+\.\d+)") { return $Matches[1] }
+        } catch {}
+    }
+    return $null
+}
+
+# Compare semver strings as integer arrays; returns 1 if $a > $b, -1 if <, 0 if equal.
+function Compare-Semver([string]$a, [string]$b) {
+    $pa = $a.TrimStart("v","V") -split '[.\-+]'
+    $pb = $b.TrimStart("v","V") -split '[.\-+]'
+    for ($i = 0; $i -lt [Math]::Max($pa.Count, $pb.Count); $i++) {
+        $na = if ($i -lt $pa.Count -and ($pa[$i] -as [int]) -ne $null) { [int]$pa[$i] } else { 0 }
+        $nb = if ($i -lt $pb.Count -and ($pb[$i] -as [int]) -ne $null) { [int]$pb[$i] } else { 0 }
+        if ($na -gt $nb) { return 1 }
+        if ($na -lt $nb) { return -1 }
+    }
+    return 0
+}
+
+# Pull `OllamaSetup.exe`'s expected SHA-256 from the official sha256sum.txt
+# in the same release. Returns lowercase hex or $null.
+function Get-OllamaExpectedSha([string]$ShaUrl) {
+    if (-not $ShaUrl) { return $null }
+    try {
+        $body = Invoke-WebRequest -Uri $ShaUrl -UseBasicParsing -TimeoutSec 15
+        foreach ($line in ($body.Content -split "`n")) {
+            $parts = $line.Trim() -split '\s+'
+            if ($parts.Count -ge 2 -and $parts[-1] -ieq "OllamaSetup.exe") {
+                return $parts[0].ToLower()
+            }
+        }
+    } catch {
+        Write-Warn2 "Could not fetch Ollama checksum file: $($_.Exception.Message)"
+    }
+    return $null
 }
 
 # ---------- Hardware preflight ----------
@@ -360,18 +429,72 @@ function Ensure-WebView2 {
 
 # ---------- Install: Ollama ----------
 function Ensure-Ollama {
-    if (Test-Command "ollama") { Write-OK "Ollama CLI present"; }
-    else {
-        Write-Step "Installing Ollama for Windows"
+    # Discover the canonical latest version up-front so we can compare against
+    # what's installed and decide between fresh-install / upgrade / skip.
+    $latest = Get-LatestOllamaRelease
+    if ($latest) {
+        Write-Host "    Ollama latest available: v$($latest.Version)" -ForegroundColor DarkGray
+    }
+
+    $installed = Get-InstalledOllamaVersion
+    $needsInstall = -not (Test-Command "ollama")
+    $needsUpgrade = $false
+
+    if (-not $needsInstall -and $latest -and $installed) {
+        if ((Compare-Semver $installed $latest.Version) -lt 0) {
+            $needsUpgrade = $true
+            Write-Step "Upgrading Ollama: v$installed -> v$($latest.Version)"
+        } else {
+            Write-OK "Ollama CLI present (v$installed, up to date)"
+        }
+    } elseif (-not $needsInstall) {
+        Write-OK "Ollama CLI present$(if ($installed) { ' (v' + $installed + ')' })"
+    }
+
+    if ($needsInstall -or $needsUpgrade) {
+        if ($needsInstall) { Write-Step "Installing Ollama for Windows" }
+
+        # Try winget first — it pulls the latest signed package automatically and
+        # handles upgrades cleanly.
+        $wingetTried = $false
         if (Test-WingetReady) {
-            $wargs = @("install", "--id", "Ollama.Ollama", "-e", "--accept-source-agreements", "--accept-package-agreements")
+            $wingetTried = $true
+            $verb = if ($needsUpgrade) { "upgrade" } else { "install" }
+            $wargs = @($verb, "--id", "Ollama.Ollama", "-e", "--accept-source-agreements", "--accept-package-agreements")
             if ($Silent) { $wargs += @("--silent") }
             & winget @wargs
-            if ($LASTEXITCODE -ne 0) { throw "winget install Ollama.Ollama failed with $LASTEXITCODE" }
-        } else {
+            if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335212) {
+                # -1978335212 = APPINSTALLER_CLI_ERROR_NO_APPLICABLE_UPDATE_FOUND
+                Write-Warn2 "winget $verb Ollama.Ollama returned $LASTEXITCODE; falling back to direct download"
+                $wingetTried = $false
+            }
+        }
+
+        if (-not $wingetTried) {
             Ensure-WorkDir
             $exe = Join-Path $WorkDir "OllamaSetup.exe"
-            Save-Url -Url $OllamaUrl -Path $exe
+
+            # Prefer the versioned URL from GitHub Releases (immutable + we know
+            # exactly which build we're shipping). Fall back to ollama.com's
+            # always-latest redirect if GitHub is unreachable.
+            $url = if ($latest) { $latest.Url } else { $OllamaUrl }
+            $expectedSha = if ($latest) { Get-OllamaExpectedSha $latest.ShaUrl } else { $null }
+
+            Save-Url -Url $url -Path $exe
+
+            # Verify SHA-256 if we got one from the release. Tampered downloads
+            # are a real risk on networks with broken/intercepted TLS.
+            if ($expectedSha) {
+                $actual = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()
+                if ($actual -ne $expectedSha) {
+                    Remove-Item $exe -ErrorAction SilentlyContinue
+                    throw "Ollama installer SHA-256 mismatch (expected $expectedSha, got $actual). Aborting."
+                }
+                Write-OK "Verified OllamaSetup.exe SHA-256"
+            } else {
+                Write-Warn2 "Skipping SHA-256 verification (no checksum file available)"
+            }
+
             $oargs = if ($Silent) { @("/SILENT") } else { @() }
             $procParams = @{
                 FilePath = $exe
@@ -382,13 +505,19 @@ function Ensure-Ollama {
             $p = Start-Process @procParams
             if ($p.ExitCode -ne 0) { throw "Ollama installer exit code $($p.ExitCode)" }
         }
+
         # Refresh PATH so we can find ollama.exe in this session.
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" +
                     [System.Environment]::GetEnvironmentVariable("Path", "User")
         if (-not (Test-Command "ollama")) {
             Write-Warn2 "ollama installed but not on PATH for this shell. Open a new terminal afterward."
         } else {
-            Write-OK "Ollama installed"
+            $newVer = Get-InstalledOllamaVersion
+            if ($newVer) {
+                Write-OK "Ollama installed (v$newVer)"
+            } else {
+                Write-OK "Ollama installed"
+            }
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,21 +8,22 @@
       "name": "cerberus-desktop",
       "version": "0.2.7",
       "dependencies": {
-        "@tauri-apps/api": "^2.1.1",
-        "@tauri-apps/plugin-dialog": "^2.7.0",
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-shell": "^2.0.1",
         "@types/dompurify": "^3.0.5",
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.4",
         "marked": "^18.0.3",
-        "vue": "^3.5.13"
+        "vue": "^3.5.34"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.1.0",
-        "@types/node": "^22.9.0",
-        "@vitejs/plugin-vue": "^5.2.1",
+        "@tauri-apps/cli": "^2.11.2",
+        "@types/node": "^22.19.19",
+        "@vitejs/plugin-vue": "^6.0.7",
+        "esbuild": "^0.28.0",
         "typescript": "~5.6.3",
-        "vite": "^8.0.10",
-        "vue-tsc": "^2.1.10"
+        "vite": "^8.0.13",
+        "vue-tsc": "^2.2.12"
       },
       "engines": {
         "node": ">=18"
@@ -47,9 +48,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -108,6 +109,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -134,9 +577,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -144,9 +587,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +604,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +621,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -195,9 +638,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +655,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -229,13 +672,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,13 +692,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,13 +712,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,13 +732,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -297,13 +752,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,13 +772,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -331,9 +792,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -348,9 +809,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -367,9 +828,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -384,9 +845,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -401,16 +862,16 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -418,9 +879,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -434,23 +895,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.2",
+        "@tauri-apps/cli-darwin-x64": "2.11.2",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
       "cpu": [
         "arm64"
       ],
@@ -465,9 +926,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
       "cpu": [
         "x64"
       ],
@@ -482,9 +943,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
       "cpu": [
         "arm"
       ],
@@ -499,13 +960,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -516,13 +980,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -533,13 +1000,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -550,13 +1020,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -567,13 +1040,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -584,9 +1060,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
       "cpu": [
         "arm64"
       ],
@@ -601,9 +1077,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
       "cpu": [
         "ia32"
       ],
@@ -618,9 +1094,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
       "cpu": [
         "x64"
       ],
@@ -635,12 +1111,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
-      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {
@@ -673,9 +1149,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -689,16 +1165,19 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
       }
     },
@@ -732,53 +1211,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -818,53 +1297,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.33"
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
-        "vue": "3.5.33"
+        "vue": "3.5.34"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
       "license": "MIT"
     },
     "node_modules/alien-signals": {
@@ -915,9 +1394,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
+      "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -933,6 +1412,48 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/estree-walker": {
@@ -1334,9 +1855,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1362,14 +1883,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1378,21 +1899,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/source-map-js": {
@@ -1451,16 +1972,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -1477,7 +1998,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1536,16 +2057,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -13,21 +13,22 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.1.1",
-    "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "@types/dompurify": "^3.0.5",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.4",
     "marked": "^18.0.3",
-    "vue": "^3.5.13"
+    "vue": "^3.5.34"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.1.0",
-    "@types/node": "^22.9.0",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@tauri-apps/cli": "^2.11.2",
+    "@types/node": "^22.19.19",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "esbuild": "^0.28.0",
     "typescript": "~5.6.3",
-    "vite": "^8.0.10",
-    "vue-tsc": "^2.1.10"
+    "vite": "^8.0.13",
+    "vue-tsc": "^2.2.12"
   },
   "engines": {
     "node": ">=18"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,28 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .manage(PullState(Mutex::new(None)))
         .manage(ChatState(Mutex::new(None)))
+        .setup(|_app| {
+            // Log Ollama daemon version once at startup so it shows up in
+            // crash reports and support tickets without depending on the user
+            // opening the right UI panel.
+            tauri::async_runtime::spawn(async {
+                let s = ollama::local_status().await;
+                if s.running {
+                    log::info!(
+                        "ollama daemon detected: version={} (cerberus desktop v{})",
+                        s.version.as_deref().unwrap_or("unknown"),
+                        env!("CARGO_PKG_VERSION")
+                    );
+                } else {
+                    log::warn!(
+                        "ollama daemon NOT running on startup ({}); cerberus desktop v{}",
+                        s.error.as_deref().unwrap_or("no detail"),
+                        env!("CARGO_PKG_VERSION")
+                    );
+                }
+            });
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             check_api,
             list_allowed_models,

--- a/src-tauri/src/ollama.rs
+++ b/src-tauri/src/ollama.rs
@@ -27,6 +27,7 @@ fn http() -> Result<reqwest::Client, reqwest::Error> {
         return Ok(c.clone());
     }
     let c = reqwest::Client::builder()
+        .user_agent(concat!("CerberusDesktop/", env!("CARGO_PKG_VERSION")))
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(60 * 60)) // long for first model pull
         .build()?;
@@ -39,11 +40,27 @@ fn http_short() -> Result<reqwest::Client, reqwest::Error> {
         return Ok(c.clone());
     }
     let c = reqwest::Client::builder()
+        .user_agent(concat!("CerberusDesktop/", env!("CARGO_PKG_VERSION")))
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(10))
         .build()?;
     let _ = HTTP_SHORT_CLIENT.set(c.clone());
     Ok(c)
+}
+
+/// Best-effort lookup of the `ollama` CLI on PATH. Returns the resolved
+/// path if found, so callers can fail fast with a clear message before
+/// kicking off a multi-GB download.
+async fn which_ollama() -> Option<std::path::PathBuf> {
+    let bin = if cfg!(windows) { "ollama.exe" } else { "ollama" };
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(bin);
+        if tokio::fs::metadata(&candidate).await.is_ok() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 // ─── Cloud: API-key verification only ──────────────────────────────────────
@@ -272,6 +289,42 @@ pub async fn pull_model(
     use std::sync::atomic::{AtomicU64, Ordering};
     use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
+    // Ollama lowercases all model names when it stores them, so any case
+    // mismatch between the API id (e.g. `Arbiter-GL9b`) and what we tell
+    // Ollama will leave the frontend's `name === "Arbiter-GL9b"` comparison
+    // failing forever — the dropdown thinks the pull never finished and
+    // re-triggers it. Normalize once here so the whole pipeline agrees.
+    let ollama_model_name = name.to_lowercase();
+
+    // Fail fast: if the ollama daemon isn't running or the CLI isn't on PATH,
+    // there's no point starting a multi-GB download.
+    {
+        let local = local_status().await;
+        if !local.running {
+            let detail = local.error.unwrap_or_else(|| "ollama daemon not running on 127.0.0.1:11434".to_string());
+            let msg = format!(
+                "Ollama is not running. Open the Ollama app (or run `ollama serve`), then try again.\n\
+                 Detail: {detail}\n\
+                 Don't have Ollama? Run the Cerberus installer again: irm https://cerberusai.dev/get | iex"
+            );
+            let _ = out.send(PullProgress {
+                status: format!("error: {msg}"),
+                completed: None, total: None, done: true, error: Some(msg.clone()),
+            });
+            return Err(anyhow::anyhow!(msg));
+        }
+        if which_ollama().await.is_none() {
+            let msg = "`ollama` CLI not found on PATH. Install Ollama from https://ollama.com/download \
+                       (or re-run the Cerberus bootstrapper: irm https://cerberusai.dev/get | iex), \
+                       then open a fresh terminal so PATH refreshes.".to_string();
+            let _ = out.send(PullProgress {
+                status: format!("error: {msg}"),
+                completed: None, total: None, done: true, error: Some(msg.clone()),
+            });
+            return Err(anyhow::anyhow!(msg));
+        }
+    }
+
     let c = http()?;
 
     // 1. Pick the smallest .gguf in the model's directory.
@@ -361,6 +414,7 @@ pub async fn pull_model(
     // One shared client so all 8 workers reuse TLS sessions and the connection pool.
     let chunk_client = Arc::new(
         reqwest::Client::builder()
+            .user_agent(concat!("CerberusDesktop/", env!("CARGO_PKG_VERSION")))
             .connect_timeout(Duration::from_secs(15))
             .timeout(Duration::from_secs(3600))
             .build()?
@@ -500,12 +554,12 @@ pub async fn pull_model(
 
     let mut child = match tokio::process::Command::new("ollama")
         .arg("create")
-        .arg(&name)
+        .arg(&ollama_model_name)
         .arg("-f")
         .arg(&modelfile_path)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn() 
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
     {
         Ok(c) => c,
         Err(e) => {
@@ -519,17 +573,42 @@ pub async fn pull_model(
         }
     };
 
-    let status = child.wait().await?;
+    let create_output = match child.wait_with_output().await {
+        Ok(o) => o,
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&modelfile_path).await;
+            let msg = format!("Failed waiting on `ollama create`: {e}");
+            let _ = out.send(PullProgress {
+                status: format!("error: {}", msg),
+                completed: None, total: None, done: true, error: Some(msg.clone()),
+            });
+            return Err(anyhow::anyhow!(msg));
+        }
+    };
     let _ = tokio::fs::remove_file(&modelfile_path).await;
 
-    if !status.success() {
-        let msg = format!("ollama create failed with status {status}");
+    if !create_output.status.success() {
+        let stderr = String::from_utf8_lossy(&create_output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&create_output.stdout).trim().to_string();
+        // Surface whatever Ollama actually said. This is the difference between
+        // "didn't work" and "GGUF metadata invalid" / "permission denied" / etc.
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("ollama create exited with {}", create_output.status)
+        };
+        let msg = format!("ollama create failed: {detail}");
         let _ = out.send(PullProgress {
-            status: format!("error: {}", msg),
+            status: format!("error: {msg}"),
             completed: None, total: None, done: true, error: Some(msg.clone()),
         });
         return Err(anyhow::anyhow!(msg));
     }
+
+    // Free disk space — we no longer need the GGUF blob, Ollama has its own copy.
+    let _ = tokio::fs::remove_file(&temp_path).await;
 
     let _ = out.send(PullProgress {
         status: "success".into(),

--- a/src-tauri/src/ollama.rs
+++ b/src-tauri/src/ollama.rs
@@ -444,6 +444,11 @@ pub async fn pull_model(
             let mut f = tokio::fs::OpenOptions::new()
                 .write(true).open(&dl_path).await?;
             f.seek(std::io::SeekFrom::Start(byte_start)).await?;
+            // Per-chunk inactivity timeout: if the upstream sends no bytes for
+            // STALL_TIMEOUT, fail this chunk so the outer error path can
+            // surface a clean message instead of letting the user stare at a
+            // frozen progress bar for the hour-long overall timeout.
+            const STALL_TIMEOUT: Duration = Duration::from_secs(30);
             loop {
                 tokio::select! {
                     biased;
@@ -452,11 +457,17 @@ pub async fn pull_model(
                             return Err(anyhow::anyhow!("cancelled"));
                         }
                     }
-                    chunk = stream.next() => {
+                    chunk = tokio::time::timeout(STALL_TIMEOUT, stream.next()) => {
                         match chunk {
-                            None => break,
-                            Some(Err(e)) => return Err(e.into()),
-                            Some(Ok(bytes)) => {
+                            Err(_) => {
+                                return Err(anyhow::anyhow!(
+                                    "chunk {i} stalled (no data for {}s); upstream may be down",
+                                    STALL_TIMEOUT.as_secs()
+                                ));
+                            }
+                            Ok(None) => break,
+                            Ok(Some(Err(e))) => return Err(e.into()),
+                            Ok(Some(Ok(bytes))) => {
                                 dl_done.fetch_add(bytes.len() as u64, Ordering::Relaxed);
                                 f.write_all(&bytes).await?;
                             }

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,16 @@ const STORAGE_KEY = "cerberus.chats.v1";
 const MODEL_KEY = "cerberus.model.v1";
 const APIKEY_KEY = "cerberus.apiKey.v1";
 
+// Ollama lowercases all model names when it stores them via `ollama create`.
+// Our cloud allowlist returns mixed-case ids (e.g. `Arbiter-GL9b`). Without
+// case-insensitive comparison the dropdown thinks the model is still missing
+// after a successful pull and re-triggers it forever. Use this everywhere
+// we compare a local Ollama model name against an allowlist id.
+function modelKey(name: string | null | undefined): string {
+  if (!name) return "";
+  return name.replace(/:latest$/, "").toLowerCase();
+}
+
 const chats = ref<Chat[]>([]);
 const activeId = ref<string | null>(null);
 const models = ref<OllamaModel[]>([]);
@@ -269,10 +279,10 @@ const pulling = ref<{ name: string; pct: number; status: string } | null>(null);
 // Drives the dropdown so users can pick undownloaded models and have them
 // auto-pulled (LM Studio-style).
 const allModelChoices = computed(() => {
-  const local = new Set(models.value.map((m) => m.name.replace(/:latest$/, '')));
+  const local = new Set(models.value.map((m) => modelKey(m.name)));
   return allowedModels.value.map((m) => ({ 
     name: m.id, 
-    downloaded: local.has(m.id),
+    downloaded: local.has(modelKey(m.id)),
     description: m.description,
     quants: m.quants
   }));
@@ -360,7 +370,7 @@ function deleteChat(id: string, evt: Event) {
 watch(selectedModel, (v) => {
   // Only persist once the model is actually present locally — otherwise a
   // pending-download choice would be remembered before it ever arrived.
-  if (v && models.value.some((m) => m.name.replace(/:latest$/, '') === v)) {
+  if (v && models.value.some((m) => modelKey(m.name) === modelKey(v))) {
     localStorage.setItem(MODEL_KEY, v);
   }
 });
@@ -368,8 +378,8 @@ watch(selectedModel, (v) => {
 // LM Studio-style: picking an undownloaded model auto-triggers the pull.
 watch(selectedModel, async (v) => {
   if (!v) return;
-  if (models.value.some((m) => m.name.replace(/:latest$/, '') === v)) return;
-  if (!allowedModels.value.some((m) => m.id === v)) return;
+  if (models.value.some((m) => modelKey(m.name) === modelKey(v))) return;
+  if (!allowedModels.value.some((m) => modelKey(m.id) === modelKey(v))) return;
   if (pulling.value) return;
   await pullModel(v);
 });
@@ -393,16 +403,16 @@ async function refreshAllowedModels() {
 async function refreshModels() {
   try {
     const list = await invoke<OllamaModel[]>("list_models");
-    const allowed = new Set(allowedModels.value.map((m) => m.id));
+    const allowed = new Set(allowedModels.value.map((m) => modelKey(m.id)));
     const filtered = allowed.size > 0
-      ? list.filter((m) => allowed.has(m.name.replace(/:latest$/, '')))
+      ? list.filter((m) => allowed.has(modelKey(m.name)))
       : [];
     models.value = filtered;
 
     if (
       selectedModel.value &&
-      !filtered.find((m) => m.name.replace(/:latest$/, '') === selectedModel.value) &&
-      !allowedModels.value.some((m) => m.id === selectedModel.value)
+      !filtered.find((m) => modelKey(m.name) === modelKey(selectedModel.value)) &&
+      !allowedModels.value.some((m) => modelKey(m.id) === modelKey(selectedModel.value))
     ) {
       selectedModel.value = "";
     }
@@ -524,7 +534,7 @@ async function send() {
   if (!text || streaming.value || !activeChat.value || !selectedModel.value) return;
   if (!apiKeyVerified.value || !apiKey.value) return;
   if (pulling.value) return;
-  if (!models.value.some((m) => m.name === selectedModel.value || m.name.replace(/:latest$/, '') === selectedModel.value)) return;
+  if (!models.value.some((m) => modelKey(m.name) === modelKey(selectedModel.value))) return;
   if (!localStatus.value.running) {
     await checkLocal();
     if (!localStatus.value.running) return;
@@ -595,7 +605,9 @@ async function send() {
 
   try {
     await invoke("chat_stream", {
-      model: selectedModel.value,
+      // Ollama stores model names lowercase. Use modelKey() so a UI value
+      // like "Arbiter-GL9b" is dispatched as "arbiter-gl9b".
+      model: modelKey(selectedModel.value),
       messages: messagesToSend,
       onEvent: channel,
     });
@@ -790,7 +802,7 @@ onMounted(async () => {
             <div class="model-card-main">
               <div class="model-card-icon">{{ m.name.charAt(0).toUpperCase() }}</div>
               <div class="model-card-info">
-                <div class="model-card-name" :title="m.name">{{ m.name.replace(/:latest$/, '') }}</div>
+                <div class="model-card-name" :title="m.name">{{ modelKey(m.name) }}</div>
                 <div class="model-card-meta">
                   <span class="model-tag">{{ formatBytes(m.size) }}</span>
                   <span v-if="m.details?.quantization_level" class="model-tag quant">{{ m.details.quantization_level }}</span>
@@ -802,8 +814,8 @@ onMounted(async () => {
             <div class="model-card-actions">
               <button
                 class="model-action-btn use"
-                v-if="selectedModel !== m.name.replace(/:latest$/, '')"
-                @click="selectedModel = m.name.replace(/:latest$/, ''); showFileManager = false"
+                v-if="modelKey(selectedModel) !== modelKey(m.name)"
+                @click="selectedModel = modelKey(m.name); showFileManager = false"
                 title="Use this model"
               >USE</button>
               <span v-else class="model-active-badge">ACTIVE</span>
@@ -1185,7 +1197,7 @@ onMounted(async () => {
           <button
             v-else
             class="send-btn"
-            :disabled="!draft.trim() || streaming || !localStatus.running || cloudStatus.kind !== 'ok' || !selectedModel || !!pulling || !models.some((m) => m.name.replace(/:latest$/, '') === selectedModel)"
+            :disabled="!draft.trim() || streaming || !localStatus.running || cloudStatus.kind !== 'ok' || !selectedModel || !!pulling || !models.some((m) => modelKey(m.name) === modelKey(selectedModel))"
             @click="send"
             aria-label="Send"
           >

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(async () => ({
   envPrefix: ["VITE_", "TAURI_ENV_*"],
   build: {
     target:
-      process.env.TAURI_ENV_PLATFORM === "windows" ? "chrome105" : "safari13",
+      process.env.TAURI_ENV_PLATFORM === "windows" ? "chrome105" : "safari14.1",
     minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
   },


### PR DESCRIPTION
## Why  fix/pull-model-case-and-errors

Three production issues bundled into one PR.

### 1. Pull-model loop (root cause of 'Lana pull never works')

Ollama lowercases all model names when storing via ollama create. The frontend was comparing its mixed-case allowlist id (e.g. `Arbiter-GL9b`) against Ollama's lowercase `arbiter-gl9b` and treated the model as still missing - so the auto-pull watcher re-triggered forever, suppressed all stderr output from `ollama create`, and left users with no diagnostic and an endless `downloading...` UI.

### 2. Frontend deps were broken

Dependabot bumped vite to v8 but `@vitejs/plugin-vue@^5.2.1` only peers v5/v6, so `npm ci` failed. Vite 8 also made esbuild an opt-in peer dep.

### 3. Installer never upgraded Ollama

Ensure-Ollama in install.ps1 skipped if any version of ollama was on PATH, never offered upgrades, used the moving redirect URL with no checksum verification.

## Changes

**ollama.rs**
- pull_model now lowercases the name before `ollama create` so it matches what Ollama actually stores
- captures stdout/stderr from `ollama create` so real errors (GGUF metadata invalid, permission denied, etc.) surface to the UI
- fails fast if the Ollama daemon is down or the CLI is missing, with a message that points to the bootstrapper
- cleans up the GGUF after import succeeds (no more accumulating multi-GB blobs)
- sets User-Agent on all reqwest clients

**App.vue**
- new modelKey() helper used everywhere we compare allowlist ids against Ollama's local model names
- chat_stream now sends the lowercase name so Ollama can find the model

**deploy/install.ps1**
- resolves latest Ollama version via GitHub Releases API up-front
- compares against the installed version, upgrades when out of date (winget --upgrade or verified .exe download)
- downloads the immutable versioned release URL instead of ollama.com's redirect
- verifies SHA-256 against the official sha256sum.txt before running the installer

**deploy/get-cerberus.ps1**
- one-liner bootstrapper hands off to deploy/install.ps1 from the same release tag, so first-time users get WebView2 + Ollama + Cerberus in one shot

**Frontend deps**
- @vitejs/plugin-vue ^5.2.1 -> ^6.0.7 (vite 8 support)
- esbuild added as explicit devDependency
- vite build target safari13 -> safari14.1 (destructuring support)
- minor patch bumps on @tauri-apps/api, @tauri-apps/plugin-dialog, @tauri-apps/cli, dompurify, vue

## Verified
- `npm ci` succeeds with the new lockfile
- `npm run build` produces a clean dist/ (192 KB JS, 42 KB CSS)
- install.ps1 -Check runs end to end on this machine and reports the right state